### PR TITLE
Expose purchase_order_number via order extension attributes in REST API

### DIFF
--- a/Plugin/Magento/Sales/Api/OrderRepository.php
+++ b/Plugin/Magento/Sales/Api/OrderRepository.php
@@ -64,7 +64,10 @@ class OrderRepository
 
             /** @var OrderExtensionInterface $target */
             $target = $extensionAttributes ?? $this->orderExtensionFactory->create();
-            $target->setPurchaseOrderNumber($order->getPurchaseOrderNumber());
+            $target->setPurchaseOrderNumber(
+                $order->getPurchaseOrderNumber() ?? $order->getData('purchase_order_number')
+            );
+
 
             $order->setExtensionAttributes($target);
         } catch (Exception $exception) {

--- a/etc/extension_attributes.xml
+++ b/etc/extension_attributes.xml
@@ -3,10 +3,11 @@
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Api/etc/extension_attributes.xsd"
 >
     <extension_attributes for="Magento\Quote\Api\Data\CartInterface">
-        <attribute code="purchase_order_number" type="string"/>
+        <attribute code="purchase_order_number" type="string" />
     </extension_attributes>
 
     <extension_attributes for="Magento\Sales\Api\Data\OrderInterface">
-        <attribute code="purchase_order_number" type="string"/>
+        <attribute code="purchase_order_number" type="string" />
     </extension_attributes>
+
 </config>


### PR DESCRIPTION
Expose **purchase_order_number** via order extension attributes in **REST API**

This allows API consumers (e.g. headless or integrations) to reliably
access the purchase order number.